### PR TITLE
Base-Fire Side Stand Ranking Fix

### DIFF
--- a/src/SiteVars.cs
+++ b/src/SiteVars.cs
@@ -31,6 +31,7 @@ namespace Landis.Extension.BaseFire
             cohorts = PlugIn.ModelCore.GetSiteVar<ISiteCohorts>("Succession.AgeCohorts");
 
             PlugIn.ModelCore.RegisterSiteVar(SiteVars.Severity, "Fire.Severity");
+            PlugIn.ModelCore.RegisterSiteVar(SiteVars.TimeOfLastFire, "Fire.TimeOfLastFire");
 
             foreach (ActiveSite site in PlugIn.ModelCore.Landscape)
             {


### PR DESCRIPTION
Base-Fire now registers the variable it uses to track the time since
last fire event. Outside libraries can now use this variable as needed.